### PR TITLE
Fix night mode: correct lighting, terrain color, and rover ground contact

### DIFF
--- a/mars.js
+++ b/mars.js
@@ -946,18 +946,16 @@ const createDustParticles = () => {
 
 const dustParticles = createDustParticles();
 
-// Enhanced Lighting for Mars
-// Warm ambient light — Mars atmosphere scatters reddish light everywhere
-const ambientIntensity = perfSettings.samsungOptimized ? 0.55 * perfSettings.ambientLightBoost :
-                         perfSettings.isMobile ? 0.55 : 0.45;
-const ambientColor = perfSettings.samsungOptimized ? 0xff9977 : 0xffb088;
+// Night lighting — cool blue-grey moonlight from Phobos, no direct sun
+const ambientIntensity = perfSettings.samsungOptimized ? 0.22 * perfSettings.ambientLightBoost :
+                         perfSettings.isMobile ? 0.22 : 0.20;
+const ambientColor = perfSettings.samsungOptimized ? 0x3355aa : 0x4466bb;
 const ambientLight = new THREE.AmbientLight(ambientColor, ambientIntensity);
 scene.add(ambientLight);
 
-// Directional light (sun) — low horizon angle for long dramatic shadows
-const sunIntensity = perfSettings.samsungOptimized ? 1.2 * perfSettings.materialBrightness :
-                     perfSettings.isMobile ? 1.0 : 1.4;
-const sunColor = perfSettings.samsungOptimized ? 0xff9955 : 0xffc080; // warm peach-orange sunlight
+// Directional light (sun) — off at night; kept at near-zero so toggle works later
+const sunIntensity = 0.0;
+const sunColor = 0xffc080; // warm peach-orange (inactive at night)
 const sunLight = new THREE.DirectionalLight(sunColor, sunIntensity);
 // Low-angle Mars sun — long shadows, dramatic look
 sunLight.position.set(-120, 55, 80);
@@ -976,18 +974,19 @@ if (!perfSettings.isMobile) {
 }
 scene.add(sunLight);
 
-// Secondary fill light — soft pink sky bounce from the opposite direction
-if (!perfSettings.isMobile) {
-  const fillLight = new THREE.DirectionalLight(0xff8866, 0.25);
-  fillLight.position.set(80, 40, -60);
-  scene.add(fillLight);
-}
+// Secondary fill light — disabled at night (no warm sky bounce without a sun)
+// if (!perfSettings.isMobile) {
+//   const fillLight = new THREE.DirectionalLight(0xff8866, 0.25);
+//   fillLight.position.set(80, 40, -60);
+//   scene.add(fillLight);
+// }
 
 // Hemisphere light — sky gradient from hazy orange to dark rust ground
-const hemisphereIntensity = perfSettings.samsungOptimized ? 0.45 * perfSettings.ambientLightBoost :
-                             perfSettings.isMobile ? 0.4 : 0.5;
-const hemisphereSkyColor = perfSettings.samsungOptimized ? 0xff8855 : 0xffaa66;  // hazy orange sky
-const hemisphereGroundColor = perfSettings.samsungOptimized ? 0xbb5511 : 0x7a2800; // dark rust ground
+// Night hemisphere — dark starry sky above, near-black Mars ground below
+const hemisphereIntensity = perfSettings.samsungOptimized ? 0.12 * perfSettings.ambientLightBoost :
+                             perfSettings.isMobile ? 0.10 : 0.10;
+const hemisphereSkyColor = 0x0d1a30;   // deep midnight blue
+const hemisphereGroundColor = 0x100806; // near-black with faint rust tint
 const hemisphereLight = new THREE.HemisphereLight(hemisphereSkyColor, hemisphereGroundColor, hemisphereIntensity);
 scene.add(hemisphereLight);
 
@@ -5503,7 +5502,7 @@ function positionRoverOnTerrain() {
 
   if (closestIntersection) {
     // Position the rover at the intersection point plus a smaller offset to be closer to ground
-    rover.position.y = closestIntersection.point.y + 1.5;
+    rover.position.y = closestIntersection.point.y + 0.3;
 
     // Only calculate terrain alignment if the slope is significant
     const normal = closestIntersection.face.normal.clone();
@@ -5539,7 +5538,7 @@ function positionRoverOnTerrain() {
     }
   } else {
     // Fallback if no intersection found
-    rover.position.y = 1.5;
+    rover.position.y = 0.3;
 
     // Just apply the yaw rotation
     rover.rotation.set(0, 0, 0);

--- a/mars.js
+++ b/mars.js
@@ -81,7 +81,7 @@ let _cachedPerformanceSettings = null;
 
 // Day/night cycle variables - declared early to avoid temporal dead zone issues
 let lastTransitionUpdate = 0;
-let currentTimeOfDay = 0.5; // 0 = midnight, 0.25 = dawn, 0.5 = noon, 0.75 = dusk, 1 = midnight
+let currentTimeOfDay = 0.0; // 0 = midnight, 0.25 = dawn, 0.5 = noon, 0.75 = dusk, 1 = midnight
 let dayNightCycleSpeed = 0.00001; // Speed of day/night cycle (smaller = slower)
 let isManualTransition = false;
 let manualTransitionTarget = null;
@@ -307,30 +307,20 @@ document.body.appendChild(renderer.domElement);
 renderer.setClearColor(0x000000, 1);
 scene.background = new THREE.Color(0x000000);
 
-// Defer night skybox creation - game starts in day mode, so create it in background
+// Night skybox — create immediately since the game starts at night
 let spaceSkybox = null;
 let _spaceSkyboxCreating = false;
 
 function ensureSpaceSkybox() {
   if (spaceSkybox || _spaceSkyboxCreating) return;
   _spaceSkyboxCreating = true;
-  // Create skybox asynchronously in the next idle period
-  if (typeof requestIdleCallback !== 'undefined') {
-    requestIdleCallback(() => {
-      spaceSkybox = createSpaceSkybox();
-      scene.add(spaceSkybox);
-      console.log('Skybox created in background (idle callback)');
-    }, { timeout: 5000 });
-  } else {
-    setTimeout(() => {
-      spaceSkybox = createSpaceSkybox();
-      console.log('Skybox created in background (setTimeout)');
-    }, 2000);
-  }
+  spaceSkybox = createSpaceSkybox();
+  scene.add(spaceSkybox);
+  console.log('Skybox created (night start)');
 }
 
-// Start creating skybox in background after a short delay (not blocking initial load)
-setTimeout(ensureSpaceSkybox, 100);
+// Create skybox right away — night mode needs it visible from frame 1
+ensureSpaceSkybox();
 
 // Fog fades distant terrain to black, matching the void behind everything
 const fogColor = 0x000000;
@@ -7539,7 +7529,7 @@ function loadNonEssentialComponents() {
 }
 
 // Add a day/night toggle and cycle
-let isDaytime = true; // Ensure this is true by default
+let isDaytime = false; // Start at night so the starry sky is visible
 console.log("Initial day/night state:", isDaytime ? "DAY" : "NIGHT");
 
 // Automatically initialize core scene elements once the game script


### PR DESCRIPTION
## Summary

- **Start at night**: `isDaytime = false`, `currentTimeOfDay = 0.0` (midnight), skybox created immediately so starry sky is visible from frame 1
- **Fix night lighting**: replaced warm daytime lights with proper night lighting — cool blue moonlight ambient (`0x4466bb` at 0.20), sun disabled (intensity 0), hemisphere set to deep midnight blue at 0.10; terrain now reads as dark reddish-sand instead of washed-out yellow/brown
- **Fix rover elevated off ground**: terrain offset corrected from `+1.5` → `+0.3` to match wheel geometry (wheel center at local y=0.5, radius=0.8, bottom at y=-0.3)

## Test plan

- [ ] Game loads directly into night scene with bright starry sky visible
- [ ] Terrain appears dark reddish-rust/sand color (not yellow or brown)
- [ ] Sky is deep blue-black with visible stars and Milky Way
- [ ] Rover wheels sit on the terrain surface (not floating above it)
- [ ] Rover drives normally across the terrain

https://claude.ai/code/session_016crKYB1dnbDXqNgHkKhyHz