### PR TITLE
Move day/night toggle initialization before scene manager creation

### DIFF
--- a/mars.js
+++ b/mars.js
@@ -5053,6 +5053,10 @@ class MarsSceneManager {
   // }
 }
 
+// Add a day/night toggle and cycle
+let isDaytime = false; // Start at night so the starry sky is visible
+console.log("Initial day/night state:", isDaytime ? "DAY" : "NIGHT");
+
 // Scene manager is created via loadNonEssentialComponents / initializeScene - no duplicate needed here
 let sceneManager = null;
 
@@ -7526,10 +7530,6 @@ function loadNonEssentialComponents() {
 
   console.log("Non-essential components queued for background loading");
 }
-
-// Add a day/night toggle and cycle
-let isDaytime = false; // Start at night so the starry sky is visible
-console.log("Initial day/night state:", isDaytime ? "DAY" : "NIGHT");
 
 // Automatically initialize core scene elements once the game script
 // has finished loading. This ensures MarsSceneManager (and the


### PR DESCRIPTION
## Summary
Relocated the day/night toggle initialization code to execute earlier in the script lifecycle, moving it from after `loadNonEssentialComponents()` to immediately after the `MarsSceneManager` class definition.

## Key Changes
- Moved `isDaytime` variable declaration and initialization from line 7530 to line 5056
- Moved associated console logging for initial day/night state to the same location
- This ensures the day/night state is established before the scene manager is instantiated

## Implementation Details
The day/night toggle initialization now occurs:
1. After the `MarsSceneManager` class is fully defined
2. Before the `sceneManager` variable is declared
3. Before `loadNonEssentialComponents()` is called

This change maintains the original behavior (starting at night for starry sky visibility) while improving the initialization order and ensuring the day/night state is available earlier in the application lifecycle.

https://claude.ai/code/session_01D9yzHB4bKBjr95nx3WK3e7