### PR TITLE
Fix rover floating in air + remove mobile start popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1099,10 +1099,6 @@
             settingsToggle.style.display = 'none';
           }
           
-          // Show mobile instructions after a delay
-          setTimeout(() => {
-            this.showMobileInstructions();
-          }, 3000);
         } else {
           // Desktop cleanup
           const mobileControls = document.getElementById('mobile-controls');

--- a/mars.js
+++ b/mars.js
@@ -5593,14 +5593,6 @@ function positionRoverOnTerrain() {
     terrainChunks.push(marsSurface);
   }
 
-  // Also include road plane meshes so the rover rides on top of roads
-  if (window.marsSceneManager && window.marsSceneManager.roads) {
-    for (const road of window.marsSceneManager.roads.values()) {
-      if (road.group && road.group.children[0]) {
-        terrainChunks.push(road.group.children[0]);
-      }
-    }
-  }
 
   // Check for intersections with all terrain chunks
   let closestIntersection = null;


### PR DESCRIPTION
## Fixes

**Rover floating in the air**
Road plane meshes were added to the terrain height raycast in the previous commit. Roads are positioned at the *averaged* Y of two settlement centers — not at actual terrain height below the rover. This caused the rover to be snapped to road elevation when it passed near any road, lifting it off the ground. Reverted terrain raycast to terrain chunks only.

**"Start Exploring Mars" popup on mobile**
`showMobileInstructions()` was being called 3 seconds after game load on mobile, showing a modal with a "Start Exploring Mars 🚀" button and instruction text. Removed the call entirely.

## Test plan
- [ ] Rover stays on terrain surface while driving — no floating
- [ ] No popup appears on mobile after load
- [ ] Joystick still drives the rover correctly

https://claude.ai/code/session_01KqcMJJiZyMFa2ZnavpZ2om

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqcMJJiZyMFa2ZnavpZ2om)_